### PR TITLE
fix(goal_passer): Only pass the goal pose

### DIFF
--- a/goal_passer/include/goal_passer/goal_passer.h
+++ b/goal_passer/include/goal_passer/goal_passer.h
@@ -44,12 +44,9 @@ namespace goal_passer {
   class GoalPasser : public nav_core::BaseGlobalPlanner {
     public:
       GoalPasser() {}
-      void initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros);
+      void initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros) {}
       bool makePlan(const geometry_msgs::PoseStamped& start,
           const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan);
-    private:
-      costmap_2d::Costmap2DROS* costmap_ros_;
-      geometry_msgs::PoseStamped last_goal_;
   };
 };
 #endif

--- a/goal_passer/src/goal_passer.cpp
+++ b/goal_passer/src/goal_passer.cpp
@@ -41,24 +41,10 @@
 PLUGINLIB_DECLARE_CLASS(goal_passer, GoalPasser, goal_passer::GoalPasser, nav_core::BaseGlobalPlanner)
 
 namespace goal_passer {
-  void GoalPasser::initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros){
-    costmap_ros_ = costmap_ros;
-    costmap_ros_->stop();
-  }
-
   bool GoalPasser::makePlan(const geometry_msgs::PoseStamped& start, 
       const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan){
     plan.clear();
-    if(last_goal_.header.stamp == goal.header.stamp && last_goal_.pose.position.x == goal.pose.position.x && last_goal_.pose.position.y == goal.pose.position.y
-        && last_goal_.pose.position.z == goal.pose.position.z && last_goal_.pose.orientation.x == goal.pose.orientation.x
-        && last_goal_.pose.orientation.y == goal.pose.orientation.y && last_goal_.pose.orientation.z == goal.pose.orientation.z
-        && last_goal_.pose.orientation.w == goal.pose.orientation.w){
-      return false;
-    }
-
     plan.push_back(goal);
-    last_goal_ = goal;
-
     return true;
   }
 };


### PR DESCRIPTION
Removed non-trivial goal_passer behavior. This planners should only pass
the goal and not stop the costmap or check for same goals.

Related to https://github.com/ros-planning/navigation_experimental/issues/15