### PR TITLE
Fix build issue on Kinetic devel for the Eigen dependency of assisted_teleop

### DIFF
--- a/assisted_teleop/CMakeLists.txt
+++ b/assisted_teleop/CMakeLists.txt
@@ -19,6 +19,7 @@ set(THIS_PACKAGE_ROS_DEPS
   pluginlib
   sensor_msgs
   filters
+  cmake_modules
 )
 
 find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS})

--- a/assisted_teleop/package.xml
+++ b/assisted_teleop/package.xml
@@ -25,6 +25,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>filters</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>cmake_modules</build_depend>
 
   <run_depend>tf</run_depend>
   <run_depend>costmap_2d</run_depend>
@@ -40,6 +41,8 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>filters</run_depend>
   <run_depend>eigen</run_depend>
+  <run_depend>cmake_modules</run_depend> 
+
 
   <export>
   <cpp cflags="-I${prefix}/include `rosboost-cfg --cflags`" lflags=""/>


### PR DESCRIPTION
Fix the build issue on Kinetic where catkin does not find the cmake_modules.