### PR TITLE
Pose follower: visualization of global plan added

### DIFF
--- a/pose_follower/include/pose_follower/pose_follower.h
+++ b/pose_follower/include/pose_follower/pose_follower.h
@@ -71,6 +71,7 @@ namespace pose_follower {
 
       void odomCallback(const nav_msgs::Odometry::ConstPtr& msg);
       bool stopped();
+      void publishPlan(const std::vector<geometry_msgs::PoseStamped> &path, const ros::Publisher &pub);
 
       tf::TransformListener* tf_;
       costmap_2d::Costmap2DROS* costmap_ros_;

--- a/pose_follower/include/pose_follower/pose_follower.h
+++ b/pose_follower/include/pose_follower/pose_follower.h
@@ -76,6 +76,7 @@ namespace pose_follower {
       tf::TransformListener* tf_;
       costmap_2d::Costmap2DROS* costmap_ros_;
       ros::Publisher vel_pub_;
+      ros::Publisher global_plan_pub_;
       double K_trans_, K_rot_, tolerance_trans_, tolerance_rot_;
       double tolerance_timeout_;
       double max_vel_lin_, max_vel_th_;

--- a/pose_follower/src/pose_follower.cpp
+++ b/pose_follower/src/pose_follower.cpp
@@ -34,6 +34,7 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
+#include <nav_msgs/Path.h>
 #include <pose_follower/pose_follower.h>
 #include <pluginlib/class_list_macros.hpp>
 
@@ -99,6 +100,7 @@ namespace pose_follower {
     ros::NodeHandle node;
     odom_sub_ = node.subscribe<nav_msgs::Odometry>("odom", 1, boost::bind(&PoseFollower::odomCallback, this, _1));
     vel_pub_ = node.advertise<geometry_msgs::Twist>("cmd_vel", 10);
+		global_plan_pub_ = node.advertise<nav_msgs::Path>("global_plan", 1);
 
     ROS_DEBUG("Initialized");
   }
@@ -141,6 +143,25 @@ namespace pose_follower {
       && fabs(base_odom.twist.twist.linear.x) <= trans_stopped_velocity_
       && fabs(base_odom.twist.twist.linear.y) <= trans_stopped_velocity_;
   }
+	
+  void PoseFollower::publishPlan(const std::vector<geometry_msgs::PoseStamped> &path,
+                               const ros::Publisher &pub) {
+		// given an empty path we won't do anything
+		if (path.empty())
+			return;
+
+		// create a path message
+		nav_msgs::Path gui_path;
+		gui_path.poses.resize(path.size());
+		gui_path.header.frame_id = path[0].header.frame_id;
+		gui_path.header.stamp = path[0].header.stamp;
+
+		// Extract the plan in world co-ordinates, we assume the path is all in the same frame
+		for (unsigned int i = 0; i < path.size(); i++) {
+			gui_path.poses[i] = path[i];
+		}
+		pub.publish(gui_path);
+	}
 
   bool PoseFollower::computeVelocityCommands(geometry_msgs::Twist& cmd_vel){
     //get the current pose of the robot in the fixed frame
@@ -229,12 +250,16 @@ namespace pose_follower {
   }
 
   bool PoseFollower::setPlan(const std::vector<geometry_msgs::PoseStamped>& global_plan){
+		global_plan_.clear();
     current_waypoint_ = 0;
     goal_reached_time_ = ros::Time::now();
     if(!transformGlobalPlan(*tf_, global_plan, *costmap_ros_, costmap_ros_->getGlobalFrameID(), global_plan_)){
       ROS_ERROR("Could not transform the global plan to the frame of the controller");
       return false;
     }
+		
+		ROS_DEBUG("global plan size: %lu", global_plan_.size());
+  	publishPlan(global_plan_, global_plan_pub_);
     return true;
   }
 

--- a/pose_follower/src/pose_follower.cpp
+++ b/pose_follower/src/pose_follower.cpp
@@ -97,10 +97,11 @@ namespace pose_follower {
     //if turn_in_place_first is true, turn in place if our heading is more than this far from facing the goal location
     node_private.param("max_heading_diff_before_moving", max_heading_diff_before_moving_, 0.17);
 
+    global_plan_pub_ = node_private.advertise<nav_msgs::Path>("global_plan", 1);
+
     ros::NodeHandle node;
     odom_sub_ = node.subscribe<nav_msgs::Odometry>("odom", 1, boost::bind(&PoseFollower::odomCallback, this, _1));
     vel_pub_ = node.advertise<geometry_msgs::Twist>("cmd_vel", 10);
-    global_plan_pub_ = node.advertise<nav_msgs::Path>("global_plan", 1);
 
     ROS_DEBUG("Initialized");
   }

--- a/pose_follower/src/pose_follower.cpp
+++ b/pose_follower/src/pose_follower.cpp
@@ -100,7 +100,7 @@ namespace pose_follower {
     ros::NodeHandle node;
     odom_sub_ = node.subscribe<nav_msgs::Odometry>("odom", 1, boost::bind(&PoseFollower::odomCallback, this, _1));
     vel_pub_ = node.advertise<geometry_msgs::Twist>("cmd_vel", 10);
-		global_plan_pub_ = node.advertise<nav_msgs::Path>("global_plan", 1);
+    global_plan_pub_ = node.advertise<nav_msgs::Path>("global_plan", 1);
 
     ROS_DEBUG("Initialized");
   }
@@ -143,25 +143,25 @@ namespace pose_follower {
       && fabs(base_odom.twist.twist.linear.x) <= trans_stopped_velocity_
       && fabs(base_odom.twist.twist.linear.y) <= trans_stopped_velocity_;
   }
-	
+
   void PoseFollower::publishPlan(const std::vector<geometry_msgs::PoseStamped> &path,
                                const ros::Publisher &pub) {
-		// given an empty path we won't do anything
-		if (path.empty())
-			return;
+  // given an empty path we won't do anything
+  if (path.empty())
+    return;
 
-		// create a path message
-		nav_msgs::Path gui_path;
-		gui_path.poses.resize(path.size());
-		gui_path.header.frame_id = path[0].header.frame_id;
-		gui_path.header.stamp = path[0].header.stamp;
+  // create a path message
+  nav_msgs::Path gui_path;
+  gui_path.poses.resize(path.size());
+  gui_path.header.frame_id = path[0].header.frame_id;
+  gui_path.header.stamp = path[0].header.stamp;
 
-		// Extract the plan in world co-ordinates, we assume the path is all in the same frame
-		for (unsigned int i = 0; i < path.size(); i++) {
-			gui_path.poses[i] = path[i];
-		}
-		pub.publish(gui_path);
-	}
+  // Extract the plan in world co-ordinates, we assume the path is all in the same frame
+  for (unsigned int i = 0; i < path.size(); i++) {
+    gui_path.poses[i] = path[i];
+  }
+  pub.publish(gui_path);
+  }
 
   bool PoseFollower::computeVelocityCommands(geometry_msgs::Twist& cmd_vel){
     //get the current pose of the robot in the fixed frame
@@ -250,16 +250,16 @@ namespace pose_follower {
   }
 
   bool PoseFollower::setPlan(const std::vector<geometry_msgs::PoseStamped>& global_plan){
-		global_plan_.clear();
+    global_plan_.clear();
     current_waypoint_ = 0;
     goal_reached_time_ = ros::Time::now();
     if(!transformGlobalPlan(*tf_, global_plan, *costmap_ros_, costmap_ros_->getGlobalFrameID(), global_plan_)){
       ROS_ERROR("Could not transform the global plan to the frame of the controller");
       return false;
     }
-		
-		ROS_DEBUG("global plan size: %lu", global_plan_.size());
-  	publishPlan(global_plan_, global_plan_pub_);
+
+    ROS_DEBUG("global plan size: %lu", global_plan_.size());
+    publishPlan(global_plan_, global_plan_pub_);
     return true;
   }
 


### PR DESCRIPTION
I have added the publishing of the global plan within the pose_follower whose poses the pose_follower follows for visualization purposes. The plan is published on the global_plan topic with the PoseFollower namespace.  Until now pose follower global and local plan topics existed but could not be visualized in RViz. Now a copy of the global planner path that is passed to the pose follower is republished for visualization. Even though some global planners publish the global path for visualization (like global_planner), some like carrot_planner dont so now the pose_follower will always publish the path that it is following not depending on the global planner used.
It was tested on ROS Kinetic, Ubuntu 16.04 and a Jackal Clearpath robot.