### PR TITLE
Pose follower: max angular vel in in-place rotation limited

### DIFF
--- a/pose_follower/src/pose_follower.cpp
+++ b/pose_follower/src/pose_follower.cpp
@@ -305,6 +305,7 @@ namespace pose_follower {
     {
       res.linear.x = 0;
       res.linear.y = 0;
+      if (fabs(res.angular.z) > max_vel_th_) res.angular.z = max_vel_th_ * sign(res.angular.z);
       if (fabs(res.angular.z) < min_in_place_vel_th_) res.angular.z = min_in_place_vel_th_ * sign(res.angular.z);
       return res;
     }
@@ -330,7 +331,7 @@ namespace pose_follower {
     if (std::isnan(res.linear.x))
         res.linear.x = 0.0;
     if (std::isnan(res.linear.y))
-        res.linear.x = 0.0;
+        res.linear.y = 0.0;
 
     //we want to check for whether or not we're desired to rotate in place
     if(sqrt(twist.linear.x * twist.linear.x + twist.linear.y * twist.linear.y) < in_place_trans_vel_){


### PR DESCRIPTION
While performing in-place rotations I noticed that the max angular velocity was not limited ( there is only a min_in_place_vel_th_ limit) and the robot can rotate in-place with higher velocity than the desired one which could be potentially dangerous. Therefore I added a line that bounds the velocity to the defined max value. In addition I noticed and fixed a small typo in the check for nan values for the linear velocities.
The changes were tested on a Clearpath Jackal robot using ROS Kinetic and Ubuntu 16.04.