### PR TITLE
Leading Slashes Removed In "Map" Frames

### DIFF
--- a/sbpl_lattice_planner/launch/move_base/global_costmap_params.yaml
+++ b/sbpl_lattice_planner/launch/move_base/global_costmap_params.yaml
@@ -1,6 +1,6 @@
 #Independent settings for the planner's costmap
 global_costmap: 
-  global_frame: /map
+  global_frame: map
   robot_base_frame: base_link
   update_frequency: 5.0
   publish_frequency: 0.0

--- a/sbpl_lattice_planner/launch/move_base/local_costmap_params_close.yaml
+++ b/sbpl_lattice_planner/launch/move_base/local_costmap_params_close.yaml
@@ -1,6 +1,6 @@
 local_costmap:
   publish_voxel_map: true
-  global_frame: /map
+  global_frame: map
   robot_base_frame: base_link
   update_frequency: 5.0
   publish_frequency: 2.0


### PR DESCRIPTION
Like the title says, the SBPL example was not running for me on Melodic. The console was spewing errors about the leading slash being invalid, so this pull request removes them. Everything now seems to work.