### PR TITLE
unused publisher removed

### DIFF
--- a/pose_follower/include/pose_follower/pose_follower.h
+++ b/pose_follower/include/pose_follower/pose_follower.h
@@ -78,7 +78,6 @@ namespace pose_follower {
 
       tf2_ros::Buffer* tf_;
       costmap_2d::Costmap2DROS* costmap_ros_;
-      ros::Publisher vel_pub_;
       ros::Publisher global_plan_pub_;
       double K_trans_, K_rot_, tolerance_trans_, tolerance_rot_;
       double tolerance_timeout_;

--- a/pose_follower/src/pose_follower.cpp
+++ b/pose_follower/src/pose_follower.cpp
@@ -101,7 +101,6 @@ namespace pose_follower {
 
     ros::NodeHandle node;
     odom_sub_ = node.subscribe<nav_msgs::Odometry>("odom", 1, boost::bind(&PoseFollower::odomCallback, this, _1));
-    vel_pub_ = node.advertise<geometry_msgs::Twist>("cmd_vel", 10);
 
     ROS_DEBUG("Initialized");
   }


### PR DESCRIPTION
There is a leftover `cmd_vel` publisher that is not used anywhere in `pose_follower`. I removed it so it does not cause confusion with the `move_base` velocity output and velocities computed through `computeVelocityCommands`.