### PR TITLE
Implement allow_unknown feature

### DIFF
--- a/sbpl_lattice_planner/README.md
+++ b/sbpl_lattice_planner/README.md
@@ -136,6 +136,10 @@ None
 
 - Only publish every nth pose on the `footprint_markers` topic.
 
+`~/SBPLLatticePlanner/allow_unknown` (`bool`, default: false)
+
+- Whether or not to allow planning through unknown space.
+
 
 ## Customizing your Motion Primitives
 

--- a/sbpl_lattice_planner/README.md
+++ b/sbpl_lattice_planner/README.md
@@ -136,7 +136,7 @@ None
 
 - Only publish every nth pose on the `footprint_markers` topic.
 
-`~/SBPLLatticePlanner/allow_unknown` (`bool`, default: false)
+`~/SBPLLatticePlanner/allow_unknown` (`bool`, default: true)
 
 - Whether or not to allow planning through unknown space.
 

--- a/sbpl_lattice_planner/include/sbpl_lattice_planner/sbpl_lattice_planner.h
+++ b/sbpl_lattice_planner/include/sbpl_lattice_planner/sbpl_lattice_planner.h
@@ -100,6 +100,8 @@ private:
   bool publish_footprint_path_;
   int visualizer_skip_poses_;
 
+  bool allow_unknown_;
+
   std::string name_;
   costmap_2d::Costmap2DROS* costmap_ros_; /**< manages the cost map for us */
   std::vector<geometry_msgs::Point> footprint_;

--- a/sbpl_lattice_planner/src/sbpl_lattice_planner.cpp
+++ b/sbpl_lattice_planner/src/sbpl_lattice_planner.cpp
@@ -123,7 +123,7 @@ void SBPLLatticePlanner::initialize(std::string name, costmap_2d::Costmap2DROS* 
     private_nh.param("publish_footprint_path", publish_footprint_path_, bool(true));
     private_nh.param<int>("visualizer_skip_poses", visualizer_skip_poses_, 5);
 
-    private_nh.param("allow_unknown", allow_unknown_, bool(false));
+    private_nh.param("allow_unknown", allow_unknown_, bool(true));
 
     name_ = name;
     costmap_ros_ = costmap_ros;

--- a/sbpl_lattice_planner/src/sbpl_lattice_planner.cpp
+++ b/sbpl_lattice_planner/src/sbpl_lattice_planner.cpp
@@ -123,6 +123,8 @@ void SBPLLatticePlanner::initialize(std::string name, costmap_2d::Costmap2DROS* 
     private_nh.param("publish_footprint_path", publish_footprint_path_, bool(true));
     private_nh.param<int>("visualizer_skip_poses", visualizer_skip_poses_, 5);
 
+    private_nh.param("allow_unknown", allow_unknown_, bool(false));
+
     name_ = name;
     costmap_ros_ = costmap_ros;
 
@@ -219,7 +221,7 @@ void SBPLLatticePlanner::initialize(std::string name, costmap_2d::Costmap2DROS* 
 //Taken from Sachin's sbpl_cart_planner
 //This rescales the costmap according to a rosparam which sets the obstacle cost
 unsigned char SBPLLatticePlanner::costMapCostToSBPLCost(unsigned char newcost){
-  if(newcost == costmap_2d::LETHAL_OBSTACLE)
+  if(newcost == costmap_2d::LETHAL_OBSTACLE || (!allow_unknown_ && newcost == costmap_2d::NO_INFORMATION))
     return lethal_obstacle_;
   else if(newcost == costmap_2d::INSCRIBED_INFLATED_OBSTACLE)
     return inscribed_inflated_obstacle_;


### PR DESCRIPTION
Other planners offer the feature of being able to not allow searching for a path in unknown space.

Recently, I was playing around with this planner and found myself in need of this feature, so I added it. I am sharing it with the world in the hope of ~becoming rich and famous~ it being useful to others.

The default behavior stays unchanged, the robot will not fear the unknown. But if the parameter `allow_unknown` is set to `false` then unknown space will be ignored from the path search.

Cheers!